### PR TITLE
avoid exit on check_config returning 1

### DIFF
--- a/assets/scripts/postinst
+++ b/assets/scripts/postinst
@@ -32,9 +32,7 @@ if [ "$1" = "configure" ] && [ -e /usr/share/debconf/confmodule ]; then
         echo "Appending settings...(Please restore configs from *.backup files when you get some error)"
 
         # setup nssswitch
-        check_config /etc/nsswitch.conf
-        nss_res=$?
-        if [ $nss_res -eq 0 ]; then
+        if check_config /etc/nsswitch.conf; then
             cp /etc/nsswitch.conf /etc/nsswitch.conf.backup
             cat <<EOS >>/etc/nsswitch.conf
 
@@ -48,9 +46,7 @@ EOS
         fi
 
         # setup sshd_config
-        check_config /etc/ssh/sshd_config
-        sshd_res=$?
-        if [ $sshd_res -eq 0 ]; then
+        if check_config /etc/ssh/sshd_config; then
             cp /etc/ssh/sshd_config /etc/ssh/sshd_config.backup
             sed -i -e "s/^UsePAM/#UsePAM/" /etc/ssh/sshd_config
             cat <<EOS >>/etc/ssh/sshd_config
@@ -65,9 +61,7 @@ EOS
         fi
 
         # setup pam
-        check_config /etc/pam.d/sshd
-        pam_res=$?
-        if [ $pam_res -eq 0 ]; then
+        if check_config /etc/pam.d/sshd; then
             if [ -e /etc/pam.d/sshd ]; then
                 cp /etc/pam.d/sshd /etc/pam.d/sshd.backup
             fi


### PR DESCRIPTION
On sectora upgrade, the `postinst` configure process may fails on check_config, due to `set -e` in https://github.com/yasuyuky/sectora/blob/8d7b84ab05b90e479c12c7304b7e8b0c6a0e3b7b/assets/scripts/postinst#L1