### PR TITLE
avoid panic in Drop impl

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -47,5 +47,7 @@ impl Connection {
 }
 
 impl Drop for Connection {
-    fn drop(&mut self) { std::fs::remove_file(&Self::socket_path(&self.conf)).unwrap_or_default(); }
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&Self::socket_path(&self.conf));
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -50,7 +50,7 @@ struct Daemon {
 impl Drop for Daemon {
     fn drop(&mut self) {
         log::debug!("Drop daemon");
-        fs::remove_file(&self.socket_conf.socket_path).expect("remove socket");
+        let _ = fs::remove_file(&self.socket_conf.socket_path);
     }
 }
 


### PR DESCRIPTION
Panics in `Drop` cause an [abrupt abort](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=761e5f9b02eb42a762de5339341b05ee) of the program when unwinding (there was already a panic, and the destructor also panics).
This is called double panic and should be avoided because an abort may lead to leakages of other resources.

This PR prevents the destructor from panicking by ignoring the filesystem error. I also changed the other `Drop` implementation as
```rust
let _ = f();
```
is the conventional way to ignore `#[must_use]` values.