### PR TITLE
fix unknown key name issue

### DIFF
--- a/assets/sectora.service
+++ b/assets/sectora.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Sectora Daemon
 After=network-online.target
+Requires=network-online.target
 
 [Service]
 Type=notify
@@ -13,4 +14,3 @@ StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
-Requires=network-online.target


### PR DESCRIPTION
# Environments

* Sectora 0.3.2
* Ubuntu 20.04(x86_64)

# Issue

systemd outputs the following message at `sectora.service` startup:

```
sudo journalctl -u sectora

~~~

Nov 20 06:38:17  systemd[1]: /etc/systemd/system/sectora.service:16: Unknown key name 'Requires' in section 'Install', ignoring.
Nov 20 06:38:17  systemd[1]: /etc/systemd/system/sectora.service:16: Unknown key name 'Requires' in section 'Install', ignoring.
```

Because `Requires` key is only available in `Unit` section.

# Fix

* move `Requires` key to `Unit` section



