### PR TITLE
clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,10 +61,47 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -225,6 +262,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -488,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -591,6 +640,7 @@ checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 name = "sectora"
 version = "0.4.0"
 dependencies = [
+ "clap 4.0.26",
  "futures",
  "glob",
  "hyper",
@@ -685,12 +735,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -701,7 +757,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -744,6 +800,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -911,6 +976,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,21 +45,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
@@ -78,7 +54,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -88,7 +64,7 @@ version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b0fba905b035a30d25c1b585bf1171690712fbb0ad3ac47214963aa4acc36c"
 dependencies = [
- "clap 4.0.26",
+ "clap",
 ]
 
 [[package]]
@@ -97,7 +73,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -262,15 +238,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -649,7 +616,7 @@ checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 name = "sectora"
 version = "0.4.0"
 dependencies = [
- "clap 4.0.26",
+ "clap",
  "clap_complete",
  "futures",
  "glob",
@@ -662,7 +629,6 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
- "structopt",
  "syslog",
  "tokio",
  "toml",
@@ -740,39 +706,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -819,15 +755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -926,28 +853,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0fba905b035a30d25c1b585bf1171690712fbb0ad3ac47214963aa4acc36c"
+dependencies = [
+ "clap 4.0.26",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +650,7 @@ name = "sectora"
 version = "0.4.0"
 dependencies = [
  "clap 4.0.26",
+ "clap_complete",
  "futures",
  "glob",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ syslog = "6.0"
 tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread"] }
 sd-notify = "0.4.1"
 clap = { version = "4.0.26", features = ["derive"] }
+clap_complete = "4.0.5"
 
 [[bin]]
 name = "sectora"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ lazy_static = "1.4"
 nix = "0.25"
 hyper = { version = "0.14.23", features = ["http1", "client", "tcp"] }
 hyper-tls = "0.5.0"
-structopt = "0.3"
 log = "0.4.17"
 syslog = "6.0"
 tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.17"
 syslog = "6.0"
 tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread"] }
 sd-notify = "0.4.1"
+clap = { version = "4.0.26", features = ["derive"] }
 
 [[bin]]
 name = "sectora"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ mod message;
 mod statics;
 mod structs;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::{generate, shells};
 use log::debug;
 use message::*;
 use std::env;
@@ -104,13 +105,14 @@ fn main() -> Result<(), Error> {
         }
         Command::Completion { shell } => {
             let shell = match shell {
-                Shell::Bash => structopt::clap::Shell::Bash,
-                Shell::Fish => structopt::clap::Shell::Fish,
-                Shell::Zsh => structopt::clap::Shell::Zsh,
-                Shell::PowerShell => structopt::clap::Shell::PowerShell,
-                Shell::Elvish => structopt::clap::Shell::Elvish,
+                Shell::Bash => shells::Shell::Bash,
+                Shell::Fish => shells::Shell::Fish,
+                Shell::Zsh => shells::Shell::Zsh,
+                Shell::PowerShell => shells::Shell::PowerShell,
+                Shell::Elvish => shells::Shell::Elvish,
             };
-            Command::clap().gen_completions_to("sectora", shell, &mut std::io::stdout());
+            let mut cmd = Command::command();
+            generate(shell, &mut cmd, "wagon", &mut std::io::stdout());
         }
     };
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod message;
 mod statics;
 mod structs;
 
+use clap::Parser;
 use log::debug;
 use message::*;
 use std::env;
@@ -12,7 +13,7 @@ use std::io::{Error, ErrorKind};
 use structopt::StructOpt;
 use structs::Config;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 #[structopt(rename_all = "kebab-case")]
 enum Command {
     /// Gets user public key
@@ -43,7 +44,7 @@ enum Command {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 #[structopt(rename_all = "kebab-case")]
 enum Shell {
     Bash,
@@ -64,7 +65,7 @@ fn show_keys(conn: &connection::Connection, user: &str) -> Result<(), Error> {
 }
 
 fn main() -> Result<(), Error> {
-    let command = Command::from_args();
+    let command = Command::parse();
     let conn = match connection::Connection::new(&format!("{:?}", command)) {
         Ok(conn) => conn,
         Err(err) => return Err(Error::new(ErrorKind::Other, format!("{:?}", err))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,17 +17,11 @@ use structs::Config;
 #[structopt(rename_all = "kebab-case")]
 enum Command {
     /// Gets user public key
-    Key {
-        #[structopt(parse(from_str))]
-        user: String,
-    },
+    Key { user: String },
     /// Executes pam check
     Pam,
     /// Check configuration
-    Check {
-        #[structopt(parse(from_os_str))]
-        confpath: std::path::PathBuf,
-    },
+    Check { confpath: std::path::PathBuf },
     /// Cleans caches up
     #[structopt(alias = "cleanup")]
     CleanUp,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use log::debug;
 use message::*;
 use std::env;
 use std::io::{Error, ErrorKind};
-use structopt::StructOpt;
 use structs::Config;
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
- Update derives
- Remove attributes for old versions
- Add clap v4 dependency
- Add clap_complete
- Use clap_complete
- Remove structopt crate
