### PR TITLE
Add testable commands with actual API

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -38,6 +38,14 @@ setup-host-root:
 setup-client-key:
 	docker cp ./keys client:/work/keys
 
+setup-client-key-env:
+	@echo "$${TEST_PRIVATE_KEY}" > $(keyfile)
+	chmod 600 $(keyfile)
+	docker exec client rm -rf /work/keys
+	docker exec client mkdir -p /work/keys/user/
+	docker cp $(keyfile) client:/work/keys/user/$(keyfile)
+	rm $(keyfile)
+
 setup-host-deb:
 	docker cp ../target/x86_64-unknown-linux-gnu/debian/sectora_$(VERSION)_amd64.deb host:/tmp/
 	docker exec host sh -c "DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/sectora_$(VERSION)_amd64.deb"

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,6 +18,15 @@ test-deb:
 	make exec-login
 	make down
 
+test-deb-from-env:
+	make up
+	make create-test-conf-env
+	make setup-deb
+	make setup-client-key-env
+	make exec-login
+	make down
+	make revert-test-conf
+
 setup-deb:
 	@echo '::group::Installing deb packages'
 	make -j 2 setup-host-deb setup-client-key

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,7 @@
 VERSION=$(shell grep "^version" ../Cargo.toml | cut -f 2 -d '"')
 dist:=ubuntu
 ver:=bionic
+user:=hunter
 
 .PHONY: test-ansible test-deb up down reset
 
@@ -67,14 +68,14 @@ up:
 exec-login:
 	@echo '$(shell tput setaf 6)LOGIN TEST START$(shell tput sgr 0)'
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) SSH $(shell tput sgr 0)'
-	@docker exec client ssh hunter@host -i keys/user/id_rsa \
+	@docker exec client ssh $(user)@host -i keys/user/id_rsa \
 		echo '"$(shell tput setaf 2)SUCCESS$(shell tput sgr 0)"'
-	@docker exec client ssh hunter@host -i keys/user/id_rsa \
+	@docker exec client ssh $(user)@host -i keys/user/id_rsa \
 		echo '::notice title=$(dist)/$(ver)::success'
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) ID $(shell tput sgr 0)'
-	@docker exec client ssh hunter@host -i keys/user/id_rsa id
+	@docker exec client ssh $(user)@host -i keys/user/id_rsa id
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) VERSION $(shell tput sgr 0)'
-	@docker exec client ssh hunter@host -i keys/user/id_rsa /usr/sbin/sectora version
+	@docker exec client ssh $(user)@host -i keys/user/id_rsa /usr/sbin/sectora version
 	@echo '$(shell tput setaf 6)LOGIN TEST END$(shell tput sgr 0)'
 
 down:

--- a/test/Makefile
+++ b/test/Makefile
@@ -54,6 +54,9 @@ create-test-conf-env:
 	@echo "name = \"${TEST_GITHUB_TEAM}\""   >> testconf.toml
 	@echo "gid = 2022"                       >> testconf.toml
 
+revert-test-conf:
+	git checkout testconf.toml
+
 setup-host-deb:
 	docker cp ../target/x86_64-unknown-linux-gnu/debian/sectora_$(VERSION)_amd64.deb host:/tmp/
 	docker exec host sh -c "DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/sectora_$(VERSION)_amd64.deb"

--- a/test/Makefile
+++ b/test/Makefile
@@ -46,6 +46,14 @@ setup-client-key-env:
 	docker cp $(keyfile) client:/work/keys/user/$(keyfile)
 	rm $(keyfile)
 
+create-test-conf-env:
+	@echo "token = \"${TEST_GITHUB_TOKEN}\""  > testconf.toml
+	@echo "org = \"${TEST_GITHUB_ORG}\""     >> testconf.toml
+	@echo                                    >> testconf.toml
+	@echo '[[team]]'                         >> testconf.toml
+	@echo "name = \"${TEST_GITHUB_TEAM}\""   >> testconf.toml
+	@echo "gid = 2022"                       >> testconf.toml
+
 setup-host-deb:
 	docker cp ../target/x86_64-unknown-linux-gnu/debian/sectora_$(VERSION)_amd64.deb host:/tmp/
 	docker exec host sh -c "DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/sectora_$(VERSION)_amd64.deb"

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,7 @@ VERSION=$(shell grep "^version" ../Cargo.toml | cut -f 2 -d '"')
 dist:=ubuntu
 ver:=bionic
 user:=hunter
+keyfile:=id_rsa
 
 .PHONY: test-ansible test-deb up down reset
 
@@ -68,14 +69,14 @@ up:
 exec-login:
 	@echo '$(shell tput setaf 6)LOGIN TEST START$(shell tput sgr 0)'
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) SSH $(shell tput sgr 0)'
-	@docker exec client ssh $(user)@host -i keys/user/id_rsa \
+	@docker exec client ssh $(user)@host -i keys/user/$(keyfile) \
 		echo '"$(shell tput setaf 2)SUCCESS$(shell tput sgr 0)"'
-	@docker exec client ssh $(user)@host -i keys/user/id_rsa \
+	@docker exec client ssh $(user)@host -i keys/user/$(keyfile) \
 		echo '::notice title=$(dist)/$(ver)::success'
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) ID $(shell tput sgr 0)'
-	@docker exec client ssh $(user)@host -i keys/user/id_rsa id
+	@docker exec client ssh $(user)@host -i keys/user/$(keyfile) id
 	@echo '$(shell tput setab 7)$(shell tput setaf 0) VERSION $(shell tput sgr 0)'
-	@docker exec client ssh $(user)@host -i keys/user/id_rsa /usr/sbin/sectora version
+	@docker exec client ssh $(user)@host -i keys/user/$(keyfile) /usr/sbin/sectora version
 	@echo '$(shell tput setaf 6)LOGIN TEST END$(shell tput sgr 0)'
 
 down:


### PR DESCRIPTION
- Allow variable setting of login user
- Make keyfile path variable-configurable
- Create a keyfile from an environment variable
- Create test conf from env vars
- Add revert command
- Add testable commands with actual API
