### PR TITLE
Specify json-server version in Dockerfile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -45,6 +45,9 @@ setup-host-root:
 	docker exec host chown -R root:root /root/.ssh/
 	docker exec host chmod -R 600 /root/.ssh/
 
+enter-host:
+	docker exec -it host bash
+
 setup-client-key:
 	docker cp ./keys client:/work/keys
 

--- a/test/json-server/Dockerfile
+++ b/test/json-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:21-alpine
 
-RUN npm install -g json-server
+RUN npm install -g json-server@0.17.4
 
 WORKDIR /data
 


### PR DESCRIPTION
This pull request updates the Dockerfile to specify the json-server version as 0.17.4. Additionally, it adds an "enter-host" command to the Makefile, allowing easier access to the host container.