### PR TITLE
Update Rust version to 1.96.0 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "SSH authentication with the GitHub team and repo"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 [dependencies]
 futures = "0.3"


### PR DESCRIPTION
## Summary

- Update `rust-version` in `Cargo.toml` from 1.95.0 to 1.96.0.
- Keep the change scoped to the Rust version declaration, matching the previous Rust version update PRs.

## Context

- Rust 1.96.0 was released on May 28, 2026: https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/

## Validation

- `cargo check`