### PR TITLE
Bump Rust toolchain to 1.96.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "SSH authentication with the GitHub team and repo"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.96.0"
+rust-version = "1.96.1"
 
 [dependencies]
 futures = "0.3"


### PR DESCRIPTION
## Summary
- Update `rust-version` in `Cargo.toml` to `1.96.1`
- Keep the crate metadata aligned with the current toolchain baseline

## Testing
- Not run (not requested)