### PR TITLE
Bump the minimum supported Rust version to 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "SSH authentication with the GitHub team and repo"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.96.1"
+rust-version = "1.97.0"
 
 [dependencies]
 toml = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "SSH authentication with the GitHub team and repo"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.97.0"
+rust-version = "1.97.1"
 
 [dependencies]
 toml = "1.1"


### PR DESCRIPTION
## Summary

- Update the crate’s minimum supported Rust version from 1.96.1 to 1.97.1.

## Testing

- Not run (not requested)